### PR TITLE
exclude newline from module name

### DIFF
--- a/bin/perl6-precompile-all
+++ b/bin/perl6-precompile-all
@@ -97,7 +97,7 @@ sub scan_use {
     my $file = shift;
     open my $fh, '<', $file;
     while (<$fh>) {
-        if (/use\s+([^;]+)/) {
+        if (/use\s+([^;\n]+)/) {
             next if $1 eq 'v6';
             precompile_module($1);
         }


### PR DESCRIPTION
現状perl 5.18などでperl6-precompile-allを実行すると

```
> /usr/bin/perl perl6-precompile-all
Unsuccessful stat on filename containing newline at /Users/skaji/src/github.com/perl6-users-jp/perl6-examples/bin/perl6-precompile-all line 55, <$_[...]> line 58.
Unsuccessful stat on filename containing newline at /Users/skaji/src/github.com/perl6-users-jp/perl6-examples/bin/perl6-precompile-all line 55, <$_[...]> line 58.
perl6-m --target=mbc --output=/Users/skaji/env/rakudobrew/moar-nom/install/share/perl6/site/lib/Crust.pm6.moarvm /Users/skaji/env/rakudobrew/moar-nom/install/share/perl6/site/lib/Crust.pm6
```

となります。perl5.18などでは`\n`を含むファイル名に対し`stat()`するとwarningが出るようです。

```
> perl -w -E 'say $^V; -f "foo\nbar"'
v5.22.0

> /usr/bin/perl -w -E 'say $^V; -f "foo\nbar"'
v5.18.2
Unsuccessful stat on filename containing newline at -e line 1.
```

よってmodule名を集めるとき`\n`を除外するようにしました。
